### PR TITLE
fixes #5 and #6 and avoids evaluation on every on/off call

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,30 @@
+var win = window;
+
+var on = function (element, event, callback, capture) {
+  element.addEventListener(event, callback, capture);
+  return callback;
+};
+
+if (win.attachEvent && !win.addEventListener) {
+  on = function (element, event, callback) {
+    element.attachEvent("on" + event, callback);
+    return callback;
+  };
+}
+
+
+var off = function (element, event, callback, capture) {
+  element.removeEventListener(event, callback, capture);
+  return callback;
+};
+
+if (win.detachEvent && !win.removeEventListener) {
+  off = function (element, event, callback) {
+    element.detachEvent("on" + event, callback);
+    return callback;
+  };
+}
+
 module.exports = on;
 module.exports.on = on;
 module.exports.off = off;
-
-function on (element, event, callback, capture) {
-  (element.addEventListener || element.attachEvent).call(element, event, callback, capture);
-  return callback;
-}
-
-function off (element, event, callback, capture) {
-  (element.removeEventListener || element.detachEvent).call(element, event, callback, capture);
-  return callback;
-}


### PR DESCRIPTION
This PR would fix legacy IE8 support mentioned in #5 and #6 but also avoid the `(element.addEventListener || element.attachEvent)` evaluation on every `on`  call. Also makes`.call()` unnecessary...
