### PR TITLE
Fixing #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,13 @@ module.exports.on = on;
 module.exports.off = off;
 
 function on (element, event, callback, capture) {
-  !element.addEventListener && (event = 'on' + event);
-  (element.addEventListener || element.attachEvent)(event, callback, capture);
-  return callback;
+  return element.addEventListener
+    ? element.addEventListener(event, callback, capture)
+    : element.attachEvent('on'+event, callback, capture);
 }
 
 function off (element, event, callback, capture) {
-  !element.removeEventListener && (event = 'on' + event);
-  (element.removeEventListener || element.detachEvent)(event, callback, capture);
-  return callback;
+  return element.removeEventListener
+    ? element.removeEventListener(event, callback, capture)
+    : element.detachEvent('on'+event, callback, capture);
 }


### PR DESCRIPTION
It breaks because the result of `(element.methodA || element.methodB)` is not bound to `element`. 