### PR TITLE
Fix for PhantomJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@ module.exports.off = off;
 
 function on (element, event, callback, capture) {
   !element.addEventListener && (event = 'on' + event);
-  (element.addEventListener || element.attachEvent)(event, callback, capture);
+  (element.addEventListener || element.attachEvent).call(element, event, callback, capture);
   return callback;
 }
 
 function off (element, event, callback, capture) {
   !element.removeEventListener && (event = 'on' + event);
-  (element.removeEventListener || element.detachEvent)(event, callback, capture);
+  (element.removeEventListener || element.detachEvent).call(element, event, callback, capture);
   return callback;
 }


### PR DESCRIPTION
In PhantomJS this is required.

Perhaps `(element.addEventListener || element.attachEvent)` resolves to an unbound method.
